### PR TITLE
Implemented Dynamic Slots for Feeding Intent and Slot Validations

### DIFF
--- a/.vscode/tasks.json.example
+++ b/.vscode/tasks.json.example
@@ -4,7 +4,7 @@
 		{
 			"type": "npm",
 			"script": "compile",
-			"path": ".ask/lambda/custom/",
+			"path": "lambda/custom/.build",
 			"group": "build",
 			"problemMatcher": [],
 			"label": "npm: compile - .ask/lambda/custom",

--- a/lambda/custom/src/babybuddy/types.ts
+++ b/lambda/custom/src/babybuddy/types.ts
@@ -59,8 +59,8 @@ interface CreateDiaperChange {
   child: string;
   wet: boolean;
   solid: boolean;
-  color: string;
-  amount: number;
+  color?: string;
+  amount?: number;
 }
 
 interface Secret {

--- a/lambda/custom/src/handlers/DiaperChangeIntentHandler.ts
+++ b/lambda/custom/src/handlers/DiaperChangeIntentHandler.ts
@@ -7,7 +7,9 @@ import {
 
 import { babyBuddy } from '../babybuddy';
 
-import { getSelectedChild, getResolvedSlotValue } from './helpers';
+import {
+  getSelectedChild,
+} from './helpers';
 
 const DiaperChangeIntentHandler: RequestHandler = {
   canHandle(handlerInput) {
@@ -21,34 +23,25 @@ const DiaperChangeIntentHandler: RequestHandler = {
 
     const name = getSlotValue(handlerInput.requestEnvelope, 'Name');
 
-    let wet = false;
-    const wetResolvedSlot = getResolvedSlotValue(
-      handlerInput.requestEnvelope,
-      'Wet'
-    );
+    console.log(`name: ${name}`);
 
-    if (wetResolvedSlot) {
-      wet = wetResolvedSlot === 'yes';
-    } else {
-      speakOutput +=
-        '  I had trouble recording whether the diaper was wet.  Setting to false.';
-    }
+    const wetValue = getSlotValue(handlerInput.requestEnvelope, 'Wet');
+    const solidValue = getSlotValue(handlerInput.requestEnvelope, 'Solid');
 
-    let solid = false;
-    const solidResolvedSlot = getResolvedSlotValue(
-      handlerInput.requestEnvelope,
-      'Solid'
-    );
+    console.log(`wetValue: ${wetValue}`);
+    console.log(`solidValue: ${solidValue}`);
 
-    if (solidResolvedSlot) {
-      solid = solidResolvedSlot === 'yes';
-    } else {
-      speakOutput +=
-        '  I had trouble recording whether the diaper was solid.  Setting to false.';
-    }
+    const wet = wetValue === 'yes';
+    const solid = solidValue === 'yes';
+
+    console.log(`wet: ${wet}`);
+    console.log(`solid: ${solid}`);
 
     const color = getSlotValue(handlerInput.requestEnvelope, 'Color');
     const amountString = getSlotValue(handlerInput.requestEnvelope, 'Amount');
+
+    console.log(`color: ${color}`);
+    console.log(`amountString: ${amountString}`);
 
     const selectedChild = await getSelectedChild(name);
 

--- a/lambda/custom/src/handlers/FeedingIntentHandler.ts
+++ b/lambda/custom/src/handlers/FeedingIntentHandler.ts
@@ -56,29 +56,8 @@ const FeedingIntentHandler: RequestHandler = {
         `requestEnvelope: ${JSON.stringify(handlerInput.requestEnvelope)}`
       );
 
-      let type = 'breast milk';
-      const typeResolvedSlot = getResolvedSlotValue(
-        handlerInput.requestEnvelope,
-        'Type'
-      );
-
-      if (typeResolvedSlot) {
-        type = typeResolvedSlot;
-      } else {
-        speakOutput += `  I had trouble recording the feeding type.  Setting to ${type}.`;
-      }
-
-      let method = 'bottle';
-      const methodResolvedSlot = getResolvedSlotValue(
-        handlerInput.requestEnvelope,
-        'Method'
-      );
-
-      if (methodResolvedSlot) {
-        method = methodResolvedSlot;
-      } else {
-        speakOutput += `  I had trouble recording the feeding type.  Setting to ${method}.`;
-      }
+      const type = getSlotValue(handlerInput.requestEnvelope, 'Type');
+      const method = getSlotValue(handlerInput.requestEnvelope, 'Method');
 
       let amount = 0;
       const amountString = getSlotValue(handlerInput.requestEnvelope, 'Amount');

--- a/lambda/custom/src/handlers/TimerIntentHandler.ts
+++ b/lambda/custom/src/handlers/TimerIntentHandler.ts
@@ -1,8 +1,13 @@
-import { RequestHandler, getRequestType, getIntentName } from 'ask-sdk-core';
+import {
+  RequestHandler,
+  getRequestType,
+  getIntentName,
+  getSlotValue
+} from 'ask-sdk-core';
 
 import { babyBuddy } from '../babybuddy';
 
-import { getResolvedSlotValue, getMinutesFromDurationString } from './helpers';
+import { getMinutesFromDurationString } from './helpers';
 
 const TimerIntentHandler: RequestHandler = {
   canHandle(handlerInput) {
@@ -15,16 +20,7 @@ const TimerIntentHandler: RequestHandler = {
   async handle(handlerInput) {
     let speakOutput = '';
 
-    const timer = getResolvedSlotValue(handlerInput.requestEnvelope, 'Timer');
-
-    if (!timer) {
-      speakOutput =
-        'That is not a valid timer type.  Valid timer types are feeding, sleeping, and tummy time';
-      return handlerInput.responseBuilder
-        .speak(speakOutput)
-        .withShouldEndSession(true)
-        .getResponse();
-    }
+    const timer = getSlotValue(handlerInput.requestEnvelope, 'Timer');
 
     const activeTimers = await babyBuddy.getActiveTimers();
     const inquiredTimer = activeTimers

--- a/lambda/custom/src/handlers/helpers.ts
+++ b/lambda/custom/src/handlers/helpers.ts
@@ -10,7 +10,7 @@ import {
 enum TimerTypes {
   FEEDING = 'feeding',
   SLEEPING = 'sleeping',
-  TUMMY_TIME = 'tummy_time',
+  TUMMY_TIME = 'tummy time',
 }
 
 const getTimersForIdentifier: (identifier: string) => Promise<Timer[]> = async (identifier: string) => {
@@ -33,22 +33,6 @@ const getSelectedChild: (name: string) => Promise<Child | undefined> = async (na
   }
 };
 
-const getResolvedSlotValue: (requestEnvelope: RequestEnvelope, slotName: string) => string | undefined = (
-  requestEnvelope: RequestEnvelope,
-  slotName: string
-) => {
-  const slot = getSlot(requestEnvelope, slotName);
-  const resolutions = slot.resolutions?.resolutionsPerAuthority;
-  const resolution = resolutions?.find(x => x !== undefined);
-
-  if (resolution?.status.code === 'ER_SUCCESS_MATCH') {
-    const value = resolution.values.find(x => x !== undefined);
-    return value?.value.name;
-  } else {
-    return undefined;
-  }
-};
-
 const getMinutesFromDurationString: (duration: string) => number = (duration: string) => {
   const [hourString, minuteString, secondString] = duration.split(':');
   const minutes =
@@ -62,6 +46,5 @@ export {
   TimerTypes,
   getTimersForIdentifier,
   getSelectedChild,
-  getResolvedSlotValue,
   getMinutesFromDurationString,
 };

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -446,6 +446,7 @@
                 },
                 {
                     "name": "StopFeedingIntent",
+                    "delegationStrategy": "SKILL_RESPONSE",
                     "confirmationRequired": false,
                     "prompts": {},
                     "slots": [
@@ -463,7 +464,13 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1347580264165.418331009805"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.566357014153.620720668664.113349554442"
+                                }
+                            ]
                         },
                         {
                             "name": "Method",
@@ -472,7 +479,19 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1347580264165.591748185545"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "isInSet",
+                                    "prompt": "Slot.Validation.566357014153.635315124524.1580400682741",
+                                    "values": [
+                                        "bottle",
+                                        "left breast",
+                                        "right breast",
+                                        "both breasts"
+                                    ]
+                                }
+                            ]
                         },
                         {
                             "name": "Amount",
@@ -513,7 +532,13 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.232215202220"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.1210990104335.190025468125.1364651012026"
+                                }
+                            ]
                         },
                         {
                             "name": "Color",
@@ -690,6 +715,33 @@
                     {
                         "type": "PlainText",
                         "value": "which child"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.566357014153.635315124524.1580400682741",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say bottle, left breast, right breast, or both breasts"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.1210990104335.190025468125.1364651012026",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either yes or no."
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.566357014153.620720668664.113349554442",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either formula, breast milk, or fortified breast milk"
                     }
                 ]
             }

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -320,22 +320,12 @@
                     "values": [
                         {
                             "name": {
-                                "value": "no",
-                                "synonyms": [
-                                    "negative",
-                                    "false"
-                                ]
+                                "value": "no"
                             }
                         },
                         {
                             "name": {
-                                "value": "yes",
-                                "synonyms": [
-                                    "obviously",
-                                    "of course",
-                                    "true",
-                                    "yeah"
-                                ]
+                                "value": "yes"
                             }
                         }
                     ]
@@ -345,22 +335,12 @@
                     "values": [
                         {
                             "name": {
-                                "value": "no",
-                                "synonyms": [
-                                    "false",
-                                    "negative"
-                                ]
+                                "value": "no"
                             }
                         },
                         {
                             "name": {
-                                "value": "yes",
-                                "synonyms": [
-                                    "obviously",
-                                    "of course",
-                                    "affirmative",
-                                    "yeah"
-                                ]
+                                "value": "yes"
                             }
                         }
                     ]
@@ -485,10 +465,10 @@
                                     "type": "isInSet",
                                     "prompt": "Slot.Validation.566357014153.635315124524.1580400682741",
                                     "values": [
-                                        "bottle",
-                                        "left breast",
                                         "right breast",
-                                        "both breasts"
+                                        "both breasts",
+                                        "bottle",
+                                        "left breast"
                                     ]
                                 }
                             ]
@@ -523,7 +503,13 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.325141027658"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.238753431432.1119166678649.805574836831"
+                                }
+                            ]
                         },
                         {
                             "name": "Solid",
@@ -547,7 +533,13 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.1417592628713"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.519221715479.1265812143869.1405679820821"
+                                }
+                            ]
                         },
                         {
                             "name": "Amount",
@@ -742,6 +734,24 @@
                     {
                         "type": "PlainText",
                         "value": "Please say either formula, breast milk, or fortified breast milk"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.519221715479.1265812143869.1405679820821",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either brown, black, green, or yellow"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.238753431432.1119166678649.805574836831",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either yes or no"
                     }
                 ]
             }

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -107,23 +107,30 @@
                         },
                         {
                             "name": "Wet",
-                            "type": "WET_TYPE",
+                            "type": "YES_NO",
                             "samples": [
                                 "{Wet}"
                             ]
                         },
                         {
                             "name": "Solid",
-                            "type": "SOLID_TYPE",
+                            "type": "YES_NO",
                             "samples": [
                                 "{Solid}"
+                            ]
+                        },
+                        {
+                            "name": "ShouldAddMoreDetails",
+                            "type": "YES_NO",
+                            "samples": [
+                                "{ShouldAddMoreDetails}"
                             ]
                         },
                         {
                             "name": "Color",
                             "type": "POOP_COLOR",
                             "samples": [
-                                "{Color} "
+                                "{Color}"
                             ]
                         },
                         {
@@ -330,22 +337,7 @@
                     ]
                 },
                 {
-                    "name": "WET_TYPE",
-                    "values": [
-                        {
-                            "name": {
-                                "value": "no"
-                            }
-                        },
-                        {
-                            "name": {
-                                "value": "yes"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "SOLID_TYPE",
+                    "name": "YES_NO",
                     "values": [
                         {
                             "name": {
@@ -463,14 +455,8 @@
                             },
                             "validations": [
                                 {
-                                    "type": "isInSet",
-                                    "prompt": "Slot.Validation.566357014153.635315124524.1580400682741",
-                                    "values": [
-                                        "right breast",
-                                        "both breasts",
-                                        "bottle",
-                                        "left breast"
-                                    ]
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.1078830774067.1378775091239.152658764803"
                                 }
                             ]
                         },
@@ -487,6 +473,7 @@
                 },
                 {
                     "name": "RecordDiaperChangeIntent",
+                    "delegationStrategy": "SKILL_RESPONSE",
                     "confirmationRequired": false,
                     "prompts": {},
                     "slots": [
@@ -499,7 +486,7 @@
                         },
                         {
                             "name": "Wet",
-                            "type": "WET_TYPE",
+                            "type": "YES_NO",
                             "confirmationRequired": false,
                             "elicitationRequired": true,
                             "prompts": {
@@ -514,7 +501,7 @@
                         },
                         {
                             "name": "Solid",
-                            "type": "SOLID_TYPE",
+                            "type": "YES_NO",
                             "confirmationRequired": false,
                             "elicitationRequired": true,
                             "prompts": {
@@ -523,7 +510,22 @@
                             "validations": [
                                 {
                                     "type": "hasEntityResolutionMatch",
-                                    "prompt": "Slot.Validation.1210990104335.190025468125.1364651012026"
+                                    "prompt": "Slot.Validation.789848152548.290406697630.670276891468"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "ShouldAddMoreDetails",
+                            "type": "YES_NO",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.789848152548.917207572680"
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.789848152548.917207572680.1285102908097"
                                 }
                             ]
                         },
@@ -533,14 +535,8 @@
                             "confirmationRequired": false,
                             "elicitationRequired": true,
                             "prompts": {
-                                "elicitation": "Elicit.Slot.1254429708032.1417592628713"
-                            },
-                            "validations": [
-                                {
-                                    "type": "hasEntityResolutionMatch",
-                                    "prompt": "Slot.Validation.519221715479.1265812143869.1405679820821"
-                                }
-                            ]
+                                "elicitation": "Elicit.Slot.443302079243.1371722513896"
+                            }
                         },
                         {
                             "name": "Amount",
@@ -724,15 +720,6 @@
                 ]
             },
             {
-                "id": "Slot.Validation.566357014153.635315124524.1580400682741",
-                "variations": [
-                    {
-                        "type": "PlainText",
-                        "value": "Please say bottle, left breast, right breast, or both breasts"
-                    }
-                ]
-            },
-            {
                 "id": "Slot.Validation.1210990104335.190025468125.1364651012026",
                 "variations": [
                     {
@@ -751,20 +738,11 @@
                 ]
             },
             {
-                "id": "Slot.Validation.519221715479.1265812143869.1405679820821",
-                "variations": [
-                    {
-                        "type": "PlainText",
-                        "value": "Please say either brown, black, green, or yellow"
-                    }
-                ]
-            },
-            {
                 "id": "Slot.Validation.238753431432.1119166678649.805574836831",
                 "variations": [
                     {
                         "type": "PlainText",
-                        "value": "Please say either yes or no"
+                        "value": "Please say either yes or no.  Was it wet?"
                     }
                 ]
             },
@@ -783,6 +761,69 @@
                     {
                         "type": "PlainText",
                         "value": "Please say either feeding, sleeping, or tummy time."
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.789848152548.290406697630.670276891468",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either yes or no.  Was it solid?"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.789848152548.803901624367.773176995604",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either yes or no"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.789848152548.128475904799.747950116698",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either yes or no"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.789848152548.917207572680",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Would you like to add more details like amount and color?"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.789848152548.917207572680.1285102908097",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either yes or no.  Would you like to add more details?"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.1078830774067.1378775091239.152658764803",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say bottle, left breast, right breast, or both breasts"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.443302079243.1371722513896",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Was is brown, black, green, or yellow?"
                     }
                 ]
             }

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -376,32 +376,19 @@
                         {
                             "id": "sleeping",
                             "name": {
-                                "value": "sleeping",
-                                "synonyms": [
-                                    "napping",
-                                    "nap",
-                                    "sleep"
-                                ]
+                                "value": "sleeping"
                             }
                         },
                         {
                             "id": "tummy_time",
                             "name": {
-                                "value": "tummy time",
-                                "synonyms": [
-                                    "tummy"
-                                ]
+                                "value": "tummy time"
                             }
                         },
                         {
                             "id": "feeding",
                             "name": {
-                                "value": "feeding",
-                                "synonyms": [
-                                    "eating",
-                                    "eat",
-                                    "feed"
-                                ]
+                                "value": "feeding"
                             }
                         }
                     ]
@@ -564,7 +551,13 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.346572812367.292275373860"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.21090862141.1133062558233.204061901969"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -580,7 +573,13 @@
                             "elicitationRequired": true,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.931506411176.1228634577598"
-                            }
+                            },
+                            "validations": [
+                                {
+                                    "type": "hasEntityResolutionMatch",
+                                    "prompt": "Slot.Validation.997851033882.462468065355.204149590670"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -752,6 +751,24 @@
                     {
                         "type": "PlainText",
                         "value": "Please say either yes or no"
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.21090862141.1133062558233.204061901969",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either feeding, sleeping, or tummy time."
+                    }
+                ]
+            },
+            {
+                "id": "Slot.Validation.997851033882.462468065355.204149590670",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Please say either feeding, sleeping, or tummy time."
                     }
                 ]
             }

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -28,6 +28,8 @@
                         }
                     ],
                     "samples": [
+                        "start a feeding for {Name}",
+                        "start a feeding",
                         "start feeding",
                         "start feeding for {Name}"
                     ]
@@ -64,6 +66,8 @@
                         }
                     ],
                     "samples": [
+                        "stop a feeding for {Name}",
+                        "stop a feeding",
                         "stop feeding",
                         "stop feeding for {Name}"
                     ]
@@ -133,6 +137,12 @@
                         }
                     ],
                     "samples": [
+                        "start a diaper change",
+                        "start a diaper change for {Name}",
+                        "record a diaper change for {Name}",
+                        "log a diaper change for {Name}",
+                        "record a diaper change",
+                        "log a diaper change",
                         "log diaper change for {Name}",
                         "record diaper change for {Name}",
                         "diaper change for {Name}",
@@ -153,6 +163,8 @@
                         }
                     ],
                     "samples": [
+                        "start a tummy time for {Name}",
+                        "start a tummy time",
                         "start tummy time for {Name}",
                         "start tummy time"
                     ]
@@ -166,6 +178,8 @@
                         }
                     ],
                     "samples": [
+                        "stop a tummy time for {Name}",
+                        "stop a tummy time",
                         "stop tummy time for {Name}",
                         "stop tummy time"
                     ]


### PR DESCRIPTION
*Description of changes:*

Two things in this PR related to Slots:

1. I figured out how to dynamically ask for slot values given previous slot values.  I was able to get this working when recording a Feeding and if the feeding type is formula.  For example, if the user says that they did a formula feeding, the skill will now assume that that a bottle was used and not prompt the user  for that slot.  @cdubz Looking for input on what other optional slots we would need to implement.  I remember you saying something about diaper changes where if you say a diaper is "wet" then you would skip the solid question and visa versa.  However, I have personally seen situations where both could be true so not sure we want to implement it there.
2. Initially when I implemented slots, there wasn't anything available to developers to actually validate what the user said to see if it matches a value in the custom slot.  It looks like only in the last few weeks that Amazon added this functionality so I added this functionality and was able to remove some custom code I had written.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
