### PR TITLE
Support additional attributes in initial diaper change intent utterance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an Alexa skill to help supplement the [Baby Buddy](https://github.com/ba
 
 ### Minimum Baby Buddy version
 
-This skill requires Baby Buddy v1.4.1 or newer as it relies on Baby Buddy's API allowing null values for the `Timer.user` field.
+This skill requires Baby Buddy [v1.11.0](https://github.com/babybuddy/babybuddy/releases/tag/v1.11.0) to allow for diaper changes without any contents.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an Alexa skill to help supplement the [Baby Buddy](https://github.com/ba
 
 ### Minimum Baby Buddy version
 
-This skill requires Baby Buddy [v1.11.0](https://github.com/babybuddy/babybuddy/releases/tag/v1.11.0) to allow for diaper changes without any contents.
+This skill requires Baby Buddy [v1.11.0](https://github.com/babybuddy/babybuddy/releases/tag/v1.11.0) or newer to allow for diaper changes without any contents.
 
 ## Usage
 
@@ -41,6 +41,7 @@ Alexa, ask Baby Buddy to stop sleeping (for [Child's Name])
 
 ```
 Alexa, ask Baby Buddy to log diaper change (for [Child's Name])
+Alexa, ask Baby Buddy to record a [wet, solid, full, empty] diaper change (for [Child's Name])
 ```
 
 ### Last Feeding

--- a/lambda/custom/src/handlers/DiaperChangeIntentHandler.ts
+++ b/lambda/custom/src/handlers/DiaperChangeIntentHandler.ts
@@ -31,15 +31,6 @@ const DiaperChangeIntentHandler: RequestHandler = {
       const request = getRequest<IntentRequest>(handlerInput.requestEnvelope);
       const intent = request.intent;
 
-      if (wetValue === 'no' && solidValue === 'no') {
-        return handlerInput.responseBuilder
-          .speak(
-            'In order to record a diaper change, it must be either wet, or solid, or both.'
-          )
-          .withShouldEndSession(true)
-          .getResponse();
-      }
-
       if (shouldAddMoreDetails === 'no') {
         if (intent && intent.slots) {
           intent.slots.Color.value = 'yellow';

--- a/lambda/custom/src/handlers/helpers.ts
+++ b/lambda/custom/src/handlers/helpers.ts
@@ -24,7 +24,7 @@ const getSelectedChild: (name: string) => Promise<Child | undefined> = async (na
 
   if (name) {
     return children.find(child =>
-      child.first_name.toLowerCase().includes(name)
+      child.first_name.toLowerCase().includes(name.toLowerCase())
     );
   } else if (children.length === 1) {
     return children[0];

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -823,7 +823,7 @@
                 "variations": [
                     {
                         "type": "PlainText",
-                        "value": "Was is brown, black, green, or yellow?"
+                        "value": "Was it brown, black, green, or yellow?"
                     }
                 ]
             }

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -141,7 +141,14 @@
                                 "{Amount} ounces",
                                 "{Amount}"
                             ]
-                        }
+                        },
+                        {
+                            "name": "Contents",
+                            "type": "DIAPER_CONTENT_TYPE",
+                            "samples": [
+                                "{Contents}"
+                            ]
+                         }
                     ],
                     "samples": [
                         "start a diaper change",
@@ -158,7 +165,9 @@
                         "start diaper change",
                         "diaper change",
                         "record diaper change",
-                        "log diaper change"
+                        "log diaper change",
+                        "record a {Contents} diaper change",
+                        "record a {Contents} diaper change for {Name}"
                     ]
                 },
                 {
@@ -377,6 +386,35 @@
                     ]
                 },
                 {
+                    "name": "DIAPER_CONTENT_TYPE",
+                    "values": [
+                        {
+                            "id": "wet",
+                            "name": {
+                                "value": "wet"
+                            }
+                        },
+                        {
+                            "id": "solid",
+                            "name": {
+                                "value": "solid"
+                            }
+                        },
+                        {
+                            "id": "full",
+                            "name": {
+                                "value": "full"
+                            }
+                        },
+                        {
+                            "id": "empty",
+                            "name": {
+                                "value": "empty"
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "TIMER_TYPE",
                     "values": [
                         {
@@ -485,34 +523,31 @@
                             "prompts": {}
                         },
                         {
+                            "name": "Contents",
+                            "type": "DIAPER_CONTENT_TYPE",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.1254429708032.325141027658"
+                            }
+                        },
+                        {
                             "name": "Wet",
                             "type": "YES_NO",
                             "confirmationRequired": false,
-                            "elicitationRequired": true,
+                            "elicitationRequired": false,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.325141027658"
-                            },
-                            "validations": [
-                                {
-                                    "type": "hasEntityResolutionMatch",
-                                    "prompt": "Slot.Validation.238753431432.1119166678649.805574836831"
-                                }
-                            ]
+                            }
                         },
                         {
                             "name": "Solid",
                             "type": "YES_NO",
                             "confirmationRequired": false,
-                            "elicitationRequired": true,
+                            "elicitationRequired": false,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.232215202220"
-                            },
-                            "validations": [
-                                {
-                                    "type": "hasEntityResolutionMatch",
-                                    "prompt": "Slot.Validation.789848152548.290406697630.670276891468"
-                                }
-                            ]
+                            }
                         },
                         {
                             "name": "ShouldAddMoreDetails",
@@ -533,7 +568,7 @@
                             "name": "Color",
                             "type": "POOP_COLOR",
                             "confirmationRequired": false,
-                            "elicitationRequired": true,
+                            "elicitationRequired": false,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.443302079243.1371722513896"
                             }
@@ -542,7 +577,7 @@
                             "name": "Amount",
                             "type": "AMAZON.NUMBER",
                             "confirmationRequired": false,
-                            "elicitationRequired": true,
+                            "elicitationRequired": false,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.592796569231"
                             }

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -24,7 +24,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -39,7 +39,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         },
                         {
                             "name": "Type",
@@ -77,7 +77,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -90,7 +90,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -103,7 +103,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         },
                         {
                             "name": "Wet",
@@ -166,7 +166,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -181,7 +181,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -232,7 +232,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -250,7 +250,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery"
+                            "type": "AMAZON.FirstName"
                         }
                     ],
                     "samples": [
@@ -410,7 +410,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery",
+                            "type": "AMAZON.FirstName",
                             "confirmationRequired": false,
                             "elicitationRequired": false,
                             "prompts": {}
@@ -425,7 +425,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery",
+                            "type": "AMAZON.FirstName",
                             "confirmationRequired": false,
                             "elicitationRequired": false,
                             "prompts": {}
@@ -479,7 +479,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery",
+                            "type": "AMAZON.FirstName",
                             "confirmationRequired": false,
                             "elicitationRequired": false,
                             "prompts": {}
@@ -600,7 +600,7 @@
                     "slots": [
                         {
                             "name": "Name",
-                            "type": "AMAZON.SearchQuery",
+                            "type": "AMAZON.FirstName",
                             "confirmationRequired": false,
                             "elicitationRequired": false,
                             "prompts": {}

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -102,6 +102,22 @@
                     "name": "RecordDiaperChangeIntent",
                     "slots": [
                         {
+                            "name": "Action",
+                            "type": "ACTION_TYPE",
+                            "samples": [
+                                "{Action}",
+                                "{Action} a",
+                                "{Action} an"
+                            ]
+                        },
+                        {
+                            "name": "Contents",
+                            "type": "DIAPER_CONTENT_TYPE",
+                            "samples": [
+                                "{Contents}"
+                            ]
+                        },
+                        {
                             "name": "Name",
                             "type": "AMAZON.FirstName"
                         },
@@ -141,33 +157,16 @@
                                 "{Amount} ounces",
                                 "{Amount}"
                             ]
-                        },
-                        {
-                            "name": "Contents",
-                            "type": "DIAPER_CONTENT_TYPE",
-                            "samples": [
-                                "{Contents}"
-                            ]
-                         }
+                        }
                     ],
                     "samples": [
-                        "start a diaper change",
-                        "start a diaper change for {Name}",
-                        "record a diaper change for {Name}",
-                        "log a diaper change for {Name}",
-                        "record a diaper change",
-                        "log a diaper change",
-                        "log diaper change for {Name}",
-                        "record diaper change for {Name}",
+                        "{Action} diaper change for {Name}",
+                        "{Action} diaper change",
+                        "{Action} a {Contents} diaper change",
+                        "{Action} a {Contents} diaper change for {Name}",
                         "diaper change for {Name}",
-                        "start diaper change for {Name}",
                         "that {Name} went poopy",
-                        "start diaper change",
-                        "diaper change",
-                        "record diaper change",
-                        "log diaper change",
-                        "record a {Contents} diaper change",
-                        "record a {Contents} diaper change for {Name}"
+                        "diaper change"
                     ]
                 },
                 {
@@ -415,6 +414,29 @@
                     ]
                 },
                 {
+                    "name": "ACTION_TYPE",
+                    "values": [
+                        {
+                            "id": "record",
+                            "name": {
+                                "value": "record"
+                            }
+                        },
+                        {
+                            "id": "log",
+                            "name": {
+                                "value": "log"
+                            }
+                        },
+                        {
+                            "id": "start",
+                            "name": {
+                                "value": "start"
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "TIMER_TYPE",
                     "values": [
                         {
@@ -523,13 +545,20 @@
                             "prompts": {}
                         },
                         {
-                            "name": "Contents",
-                            "type": "DIAPER_CONTENT_TYPE",
+                            "name": "Action",
+                            "type": "ACTION_TYPE",
                             "confirmationRequired": false,
                             "elicitationRequired": false,
                             "prompts": {
                                 "elicitation": "Elicit.Slot.1254429708032.325141027658"
                             }
+                        },
+                        {
+                            "name": "Contents",
+                            "type": "DIAPER_CONTENT_TYPE",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {}
                         },
                         {
                             "name": "Wet",


### PR DESCRIPTION
*Issue #, if available:* #6

*Description of changes:*
This change makes it so users can attach diaper change information in the initial utterance to Alexa.  For example, now someone can say "Alexa, ask Baby Buddy to record a wet diaper change", which will automatically flag this as a wet diaper (and not solid).  Four values are "supported": `wet`, `solid`, `full` (which is both wet and solid), and `empty` (which is neither).

This changeset also refactors how first names are parsed - it uses Amazon's built in [`AMAZON.FirstName`](https://developer.amazon.com/en-US/docs/alexa/custom-skills/slot-type-reference.html) slot type, which is in "Public beta".  It seems unlikely that Amazon will completely revoke the type altogether, but it states that it reserves the right to alter it based on feedback.  Considering the use case here, and the relative niche-ness of this skill, I feel this is okay, but open to discussion.

Note: this changes how we prompt for some of the "additional information" in the intent.  Previously, the skill marked "wet", "solid", "ounces" and "color" as required slot values, and if we skipped filling them in it just guessed.  This allows the code to rely on the builtin validation from the Alexa developer kit to prompt with elicitations defined in the `en-US.json` file.  Unfortunately, there's a longstanding issue where you cannot manually fill in required custom values with validation.  It is unclear if this will be changed anytime soon.  Thus - this PR moves these attributes to no longer be required, and manually prompts within the code itself (rather than relying on Alexa's built in elicitation).  Unfortunately, that removes the code from the locale specific file, but considering there's only `en-US`, and there were other prompts being manually specified in the code anyway, I felt it was a reasonable stopgap.

Based on my browsing of other Alexa skills, the "best practice" here might be to split out these additional questions into separate intents, and manage the values through a session.  This seems beyond the scope of this PR, but I think it's worth calling out in case someone comes along later on and wants to migrate the code to that structure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
