### PR TITLE
Record a Tummy Time without starting a timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Alexa, ask Baby Buddy to start tummy time (for [Child's Name])
 Alexa, ask Baby Buddy to stop tummy time (for [Child's Name])
 ```
 
+Alternatively, you can record a Tummy Time entry with a duration, which will create an entry ending at the current time.
+
+```
+Alexa, ask Baby Buddy to record a 15 minute tummy time (for [Child's Name])
+Alexa, ask Baby Buddy to record a tummy time (for [Child's Name])
+Alexa, ask Baby Buddy to log a 25 minute tummy time (for [Child's Name])
+Alexa, ask Baby Buddy to log a tummy time (for [Child's Name])
+```
+
+If a duration is not provided Alexa will prompt you to provide it.
+
 ### Sleeping
 
 ```

--- a/lambda/custom/src/babybuddy/api.ts
+++ b/lambda/custom/src/babybuddy/api.ts
@@ -9,6 +9,7 @@ import {
   CreateDiaperChange,
   Secret,
   URLS,
+  CreateTummyTime,
 } from './types';
 
 const fetchSecrets: () => Promise<Secret> = async () => {
@@ -173,13 +174,8 @@ class BabyBuddyApi {
     return await this.postRequest(URLS.DIAPER_CHANGES, body);
   }
 
-  async createTummyTime(childId, timerId) {
-    const body = {
-      child: childId,
-      timer: timerId,
-    };
-
-    return await this.postRequest(URLS.TUMMY_TIMES, body);
+  async createTummyTime(tummyTime: CreateTummyTime) {
+    return await this.postRequest(URLS.TUMMY_TIMES, tummyTime);
   }
 }
 

--- a/lambda/custom/src/babybuddy/index.ts
+++ b/lambda/custom/src/babybuddy/index.ts
@@ -9,7 +9,8 @@ import {
   Timer,
   Child,
   CreateDiaperChange,
-  URLS
+  URLS,
+  CreateTummyTime
 } from './types';
 
 export {
@@ -22,5 +23,6 @@ export {
   Child,
   CreateDiaperChange,
   URLS,
-  babyBuddy
+  babyBuddy,
+  CreateTummyTime
 };

--- a/lambda/custom/src/babybuddy/types.ts
+++ b/lambda/custom/src/babybuddy/types.ts
@@ -35,6 +35,21 @@ interface Feeding {
   amount: number;
 }
 
+interface TummyTimeBase {
+  child: string;
+}
+
+interface CreateTummyTimeFromTimer extends TummyTimeBase {
+  timer: string;
+}
+
+interface CreateTummyTimeFromStartAndEnd extends TummyTimeBase {
+  start: string;
+  end: string;
+}
+
+type CreateTummyTime = CreateTummyTimeFromTimer | CreateTummyTimeFromStartAndEnd;
+
 interface Timer {
   id: string;
   child: string;
@@ -97,5 +112,6 @@ export {
   CreateDiaperChange,
   CloudflareZeroTrustSecret,
   Secret,
-  URLS
+  URLS,
+  CreateTummyTime
 };

--- a/lambda/custom/src/handlers/RecordTummyTimeIntentHandler.ts
+++ b/lambda/custom/src/handlers/RecordTummyTimeIntentHandler.ts
@@ -1,0 +1,76 @@
+import {
+  getRequestType,
+  getIntentName,
+  RequestHandler,
+  getSlotValue,
+  getDialogState,
+  getRequest,
+} from 'ask-sdk-core';
+
+import { IntentRequest } from 'ask-sdk-model';
+
+import * as moment from 'moment';
+
+import { babyBuddy } from '../babybuddy';
+
+import {
+  getSelectedChild,
+} from './helpers';
+
+const RecordTummyTimeIntentHandler: RequestHandler = {
+  canHandle(handlerInput) {
+    return (
+      getRequestType(handlerInput.requestEnvelope) === 'IntentRequest' &&
+      getIntentName(handlerInput.requestEnvelope) === 'RecordTummyTimeIntent'
+    );
+  },
+  async handle(handlerInput) {
+    if (getDialogState(handlerInput.requestEnvelope) !== 'COMPLETED') {
+      const request = getRequest<IntentRequest>(handlerInput.requestEnvelope);
+      const intent = request.intent;
+
+      return handlerInput.responseBuilder
+        .addDelegateDirective(intent)
+        .withShouldEndSession(false)
+        .getResponse();
+    }
+
+    // AMAZON.DURATION gets provided as an ISO-8601 duration
+    const durationISO8601 = getSlotValue(handlerInput.requestEnvelope, 'Duration');
+    const duration = moment.duration(durationISO8601);
+
+    const now = moment();
+    const beginning = moment().subtract(duration);
+
+    const name = getSlotValue(handlerInput.requestEnvelope, 'Name');
+
+    const selectedChild = await getSelectedChild(name);
+
+    if (!selectedChild) {
+      return handlerInput.responseBuilder
+        .speak(
+          'Please specify which child by saying, Ask Baby Buddy to record a feeding for Jack.'
+        )
+        .getResponse();
+    }
+
+    console.log(selectedChild);
+
+    const speakOutput = `Recording tummy time for ${selectedChild.first_name}`;
+
+    await babyBuddy.createTummyTime(
+      {
+        child: selectedChild.id,
+        start: beginning.toISOString(),
+        end: now.toISOString()
+      }
+    );
+
+    return handlerInput.responseBuilder
+      .speak(speakOutput)
+      .withShouldEndSession(true)
+      .getResponse();
+  },
+};
+
+export { RecordTummyTimeIntentHandler };

--- a/lambda/custom/src/handlers/TummyTimeIntentHandler.ts
+++ b/lambda/custom/src/handlers/TummyTimeIntentHandler.ts
@@ -49,7 +49,11 @@ const TummyTimeIntentHandler: RequestHandler = {
       }
     } else if (selectedChildTimer) {
       speakOutput = `Stopping tummy time for ${selectedChild.first_name}.`;
-      await babyBuddy.createTummyTime(selectedChild.id, selectedChildTimer.id);
+      await babyBuddy.createTummyTime(
+        {
+          child: selectedChild.id,
+          timer: selectedChildTimer.id
+        });
     } else {
       speakOutput = `You don't have a tummy time session started for ${selectedChild.first_name}`;
     }

--- a/lambda/custom/src/handlers/index.ts
+++ b/lambda/custom/src/handlers/index.ts
@@ -11,6 +11,7 @@ import { SessionEndedRequestHandler } from './SessionEndedRequestHandler';
 import { SleepIntentHandler } from './SleepIntentHandler';
 import { TotalFeedingsIntentHandler } from './TotalFeedingsIntentHandler';
 import { TummyTimeIntentHandler } from './TummyTimeIntentHandler';
+import { RecordTummyTimeIntentHandler } from './RecordTummyTimeIntentHandler';
 
 export {
   CancelAndStopIntentHandler,
@@ -26,4 +27,5 @@ export {
   SleepIntentHandler,
   TotalFeedingsIntentHandler,
   TummyTimeIntentHandler,
+  RecordTummyTimeIntentHandler,
 };

--- a/lambda/custom/src/index.ts
+++ b/lambda/custom/src/index.ts
@@ -23,6 +23,7 @@ import {
   SleepIntentHandler,
   TotalFeedingsIntentHandler,
   TummyTimeIntentHandler,
+  RecordTummyTimeIntentHandler,
 } from './handlers';
 
 const handler = SkillBuilders.custom()
@@ -38,6 +39,7 @@ const handler = SkillBuilders.custom()
     HelpIntentHandler,
     CancelAndStopIntentHandler,
     SessionEndedRequestHandler,
+    RecordTummyTimeIntentHandler,
     IntentReflectorHandler // make sure IntentReflectorHandler is last so it doesn't override your custom intent handlers
   )
   .addErrorHandlers(ErrorHandler)

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -170,6 +170,29 @@
                     ]
                 },
                 {
+                    "name": "RecordTummyTimeIntent",
+                    "slots": [
+                        {
+                            "name": "Name",
+                            "type": "AMAZON.FirstName"
+                        },
+                        {
+                            "name": "Duration",
+                            "type": "AMAZON.DURATION"
+                         }
+                    ],
+                    "samples": [
+                        "record a tummy time for {Name}",
+                        "record a tummy time",
+                        "record a {Duration} tummy time",
+                        "record a {Duration} tummy time for {Name}",
+                        "log a tummy time",
+                        "log a tummy time for {Name}",
+                        "log a {Duration} tummy time",
+                        "log a {Duration} tummy time for {Name}"
+                    ]
+                },
+                {
                     "name": "StartTummyTimeIntent",
                     "slots": [
                         {
@@ -670,6 +693,29 @@
                             "prompts": {}
                         }
                     ]
+                },
+                {
+                    "name": "RecordTummyTimeIntent",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "Name",
+                            "type": "AMAZON.FirstName",
+                            "confirmationRequired": false,
+                            "elicitationRequired": false,
+                            "prompts": {}
+                        },
+                        {
+                            "name": "Duration",
+                            "type": "AMAZON.DURATION",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.443302079243.1371722513897"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -890,7 +936,16 @@
                         "value": "Was it brown, black, green, or yellow?"
                     }
                 ]
-            }
+            },
+            {
+                "id": "Elicit.Slot.443302079243.1371722513897",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "How long was the tummy time?"
+                    }
+                ]
+             }
         ]
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This allows someone to record a tummy time without starting a timer.

Examples:
"Alexa, ask Baby Buddy to record a 15 minute tummy time" - this will create a fully qualified tummy time entry of 15 minutes, ending at the time of the command.

or

"Alexa, ask Baby Buddy to record tummy time" which will then prompt  the user to provide the duration, which will then be applied to the current time.

A few notes:

I only included a single duration with this PR that ends the tummy time when the user invokes the command.  It's very possible to include an explicit end time (like "Alexa, ask Baby Buddy to record a 15 minute timer ending at 12:05pm" or something like that).

I initially started this codepath for feedings, but there are a lot more variables involved with a feeding entry and I couldn't quite come up with a way to naturally construct commands without resorting to a back and forth "yes / no" session with Alexa.  So - if there are ideas there - I'd definitely be open to discussing options.  I'd also like to get the feeding entry a little smarter in general (ie, I don't think we need to ask people what the feeding method is if you've indicated it's a formula feeding, for instance)

Lastly, I opted for a totally new handler because the existing one is mostly focused on the timer aspect of things.  I think _generally_ speaking keeping the intent handlers fairly lightweight makes the most sense - but again - open to feedback on this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
