### PR TITLE
Wake Window Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ Alexa, ask Baby Buddy to start sleeping (for [Child's Name])
 Alexa, ask Baby Buddy to stop sleeping (for [Child's Name])
 Alexa, ask Baby Buddy to record 15 minutes of sleep (for [Child's Name])
 Alexa, ask Baby Buddy to log 25 minutes of sleep (for [Child's Name])
+Alexa, ask Baby Buddy how long [Child's Name] has been awake
 ```
+Note: in order for the Alexa skill to know if your child is currently sleeping,
+the active timer tracking their sleep must have the name "sleeping".
+If you start the sleep session from the Alexa skill, the timer name will already be named correctly.
 
 ### Diaper Change
 

--- a/lambda/custom/src/babybuddy/api.ts
+++ b/lambda/custom/src/babybuddy/api.ts
@@ -12,6 +12,7 @@ import {
   CreateTummyTime,
   CreateSleep,
   DiaperChange,
+  Sleep,
 } from "./types";
 
 const fetchSecrets: () => Promise<Secret> = async () => {
@@ -210,6 +211,18 @@ class BabyBuddyApi {
     }
 
     return diaperChange.results[0];
+  }
+
+  async getLastSleep(childId: string): Promise<Sleep | null> {
+    const sleeps: GetResponse<Sleep> = await this.getRequest(
+      `${URLS.SLEEP}?child=${childId}&limit=1`
+    );
+
+    if (sleeps.count === 0) {
+      return null;
+    }
+
+    return sleeps.results[0];
   }
 
   async createTummyTime(tummyTime: CreateTummyTime) {

--- a/lambda/custom/src/babybuddy/types.ts
+++ b/lambda/custom/src/babybuddy/types.ts
@@ -92,6 +92,13 @@ interface CloudflareZeroTrustSecret {
   cfAccessClientSecret: string;
 }
 
+interface Sleep {
+  child: string;
+  duration: string;
+  start: string;
+  end: string;
+}
+
 interface Secret {
   apiKey: string;
   apiUrl: string;
@@ -125,4 +132,5 @@ export {
   CreateSleep,
   SimpleChildTimer,
   DiaperChange,
+  Sleep,
 };

--- a/lambda/custom/src/handlers/RecordSimpleDurationIntentHandler.ts
+++ b/lambda/custom/src/handlers/RecordSimpleDurationIntentHandler.ts
@@ -48,7 +48,7 @@ const RecordSimpleDurationIntentHandler: RequestHandler = {
         : "tummy time";
 
     const now = moment();
-    const beginning = moment().subtract(duration);
+    const beginning = now.subtract(duration);
 
     const name = getSlotValue(handlerInput.requestEnvelope, "Name");
 

--- a/lambda/custom/src/handlers/WakeWindowHandler.ts
+++ b/lambda/custom/src/handlers/WakeWindowHandler.ts
@@ -1,0 +1,78 @@
+import {
+  RequestHandler,
+  getRequestType,
+  getIntentName,
+  getSlotValue,
+} from "ask-sdk-core";
+
+import * as moment from "moment";
+
+import { babyBuddy } from "../babybuddy";
+
+import {
+  getSelectedChild,
+  getTimersForIdentifier,
+  TimerTypes,
+} from "./helpers";
+
+const WakeWindowIntentHandler: RequestHandler = {
+  canHandle(handlerInput) {
+    return (
+      getRequestType(handlerInput.requestEnvelope) === "IntentRequest" &&
+      getIntentName(handlerInput.requestEnvelope) === "WakeWindowIntent"
+    );
+  },
+  async handle(handlerInput) {
+    const name = getSlotValue(handlerInput.requestEnvelope, "Name");
+
+    console.log(`name: ${name}`);
+
+    const selectedChild = await getSelectedChild(name);
+
+    console.log(`selectedChild: ${JSON.stringify(selectedChild)}`);
+
+    if (!selectedChild) {
+      return handlerInput.responseBuilder
+        .speak(
+          "Please specify which child by saying, Ask Baby Buddy how long Jack has been awake."
+        )
+        .getResponse();
+    }
+
+    const sleepTimers = await getTimersForIdentifier(TimerTypes.SLEEPING);
+
+    const selectedChildTimer = sleepTimers.find(
+      (timer) => timer.child === selectedChild.id
+    );
+
+    if (selectedChildTimer) {
+      return handlerInput.responseBuilder
+        .speak(`${selectedChild.first_name} is currently sleeping.`)
+        .getResponse();
+    }
+
+    const lastSleep = await babyBuddy.getLastSleep(selectedChild.id);
+
+    if (!lastSleep) {
+      return handlerInput.responseBuilder
+        .speak(
+          `There is no recorded sleep session for ${selectedChild.first_name}`
+        )
+        .getResponse();
+    }
+
+    const now = moment();
+    const humanDuration = moment.duration(now.diff(lastSleep.end)).humanize();
+    const endFormatted = moment.parseZone(lastSleep.end).format("h:mm A");
+
+    const speakOutput = `${selectedChild.first_name} has been awake for ${humanDuration}, starting at ${endFormatted}`;
+
+    return handlerInput.responseBuilder
+      .speak(speakOutput)
+      .reprompt(speakOutput)
+      .withShouldEndSession(true)
+      .getResponse();
+  },
+};
+
+export { WakeWindowIntentHandler };

--- a/lambda/custom/src/handlers/index.ts
+++ b/lambda/custom/src/handlers/index.ts
@@ -13,6 +13,7 @@ import { TotalFeedingsIntentHandler } from "./TotalFeedingsIntentHandler";
 import { TummyTimeIntentHandler } from "./TummyTimeIntentHandler";
 import { RecordSimpleDurationIntentHandler } from "./RecordSimpleDurationIntentHandler";
 import { LastDiaperChangeIntentHandler } from "./LastDiaperChangeIntentHandler";
+import { WakeWindowIntentHandler } from "./WakeWindowHandler";
 
 export {
   CancelAndStopIntentHandler,
@@ -30,4 +31,5 @@ export {
   TummyTimeIntentHandler,
   RecordSimpleDurationIntentHandler,
   LastDiaperChangeIntentHandler,
+  WakeWindowIntentHandler,
 };

--- a/lambda/custom/src/index.ts
+++ b/lambda/custom/src/index.ts
@@ -25,6 +25,7 @@ import {
   TummyTimeIntentHandler,
   RecordSimpleDurationIntentHandler,
   LastDiaperChangeIntentHandler,
+  WakeWindowIntentHandler,
 } from "./handlers";
 
 const handler = SkillBuilders.custom()
@@ -42,6 +43,7 @@ const handler = SkillBuilders.custom()
     SessionEndedRequestHandler,
     RecordSimpleDurationIntentHandler,
     LastDiaperChangeIntentHandler,
+    WakeWindowIntentHandler,
     IntentReflectorHandler // make sure IntentReflectorHandler is last so it doesn't override your custom intent handlers
   )
   .addErrorHandlers(ErrorHandler)

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -99,6 +99,19 @@
                     ]
                 },
                 {
+                    "name": "WakeWindowIntent",
+                    "slots": [
+                        {
+                            "name": "Name",
+                            "type": "AMAZON.FirstName"
+                        }
+                    ],
+                    "samples": [
+                        "how long has {Name} been awake",
+                        "how long has {Name} been awake for"
+                    ]
+                },
+                {
                     "name": "RecordDiaperChangeIntent",
                     "slots": [
                         {
@@ -810,7 +823,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "WakeWindowIntent",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "Name",
+                            "type": "AMAZON.FirstName",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.491193288216.955936429502"
+                            }
+                        }
+                    ]
                 }
+
             ],
             "delegationStrategy": "ALWAYS"
         },


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add an intent handler to query for the current "wake window", by issuing the command "Alexa, ask Baby Buddy how long has [Child's name] been awake".

We frequently look at Baby Buddy on our phone to determine how long our child has been awake between naps (or, more poignantly, we ask our partners).

I only added one utterance for this command as that's all I could really think of but they're pretty easy to add on either now or in the future if there's other natural ways to ask Alexa for this information.

I also suspect this will run into the same issue outlined in https://github.com/babybuddy/babybuddy/issues/588 - but I'm happy to update this skill when that ticket gets implemented.

EDIT: Also - I updated the `SimpleDurationHandler` as well to fix a minor bug for simplicity of review.  It's unrelated to this PR but it's also pretty trivial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
